### PR TITLE
fix: ASCII compliance - replace → symbols and convert German comments

### DIFF
--- a/tasker/executors/parallel_executor.py
+++ b/tasker/executors/parallel_executor.py
@@ -348,10 +348,10 @@ class ParallelExecutor(BaseExecutor):
                         executor_instance._check_shutdown()
 
                     if retry_config:
-                        # Mit retry config → .1, .2, etc.
+                        # With retry config -> .1, .2, etc.
                         future = thread_executor.submit(ParallelExecutor.execute_single_task_with_retry, task, master_timeout, retry_config, executor_instance=executor_instance)
                     else:
-                        # Ohne retry config → keine Nummer
+                        # Without retry config -> no number
                         future = thread_executor.submit(ParallelExecutor.execute_single_task_for_parallel, task, master_timeout, "", executor_instance=executor_instance)
                     future_to_task[future] = task
                 

--- a/tasker_orig.py
+++ b/tasker_orig.py
@@ -1993,7 +1993,7 @@ class TaskExecutor:
         if next_condition == 'success':
             self.log(f"Task {task_id}: Legacy 'success' condition treated as 'all_success'")
             result = self.evaluate_parallel_next_condition('all_success', results)
-            self.log(f"Task {task_id}: Condition 'success' (→ all_success) evaluated to: {result}")
+            self.log(f"Task {task_id}: Condition 'success' (-> all_success) evaluated to: {result}")
             return result
         
         # Handle parallel-specific conditions (simplified syntax)
@@ -2133,10 +2133,10 @@ class TaskExecutor:
                         self._check_shutdown()
 
                     if retry_config:
-                        # Mit retry config → .1, .2, etc.
+                        # With retry config -> .1, .2, etc.
                         future = executor.submit(self.execute_single_task_with_retry, task, master_timeout, retry_config)
                     else:
-                        # Ohne retry config → keine Nummer
+                        # Without retry config -> no number
                         future = executor.submit(self.execute_single_task_for_parallel, task, master_timeout, "")
                     future_to_task[future] = task
                 
@@ -2376,7 +2376,7 @@ class TaskExecutor:
         if next_condition == 'success':
             self.log(f"Task {task_id}: Legacy 'success' condition treated as 'all_success'")
             result = self.evaluate_parallel_next_condition('all_success', results)
-            self.log(f"Task {task_id}: Condition 'success' (→ all_success) evaluated to: {result}")
+            self.log(f"Task {task_id}: Condition 'success' (-> all_success) evaluated to: {result}")
             return result
         
         # Handle conditional-specific conditions (reuse parallel logic)


### PR DESCRIPTION
- Replace all → symbols with -> in tasker_orig.py and parallel_executor.py
- Convert German comments to English:
  * "Mit retry config → .1, .2, etc." -> "With retry config -> .1, .2, etc."
  * "Ohne retry config → keine Nummer" -> "Without retry config -> no number"

Issues fixed:
- Non-ASCII characters violating CLAUDE.md requirements
- Encoding compatibility issues across different systems
- German language comments affecting international maintainability

Files updated:
- tasker_orig.py: 4 instances (2 log messages, 2 comments)
- tasker/executors/parallel_executor.py: 2 instances (comments only)

All functionality preserved - comprehensive test execution successful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Standardized log messages to use ASCII arrows (->) instead of Unicode (→) for clearer readability across environments.
  - Replaced remaining German phrases in retry-related logs with English equivalents to ensure consistency.
- Documentation
  - Updated inline comments to reflect the new log phrasing.
  
No functional changes; behavior and APIs remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->