### PR TITLE
fix: Add duration validation and correct sleep range test benchmarks

### DIFF
--- a/test_cases/functional/metadata_sleep_range_test.txt
+++ b/test_cases/functional/metadata_sleep_range_test.txt
@@ -1,4 +1,4 @@
-# TEST_METADATA: {"description": "Sleep Block test - testing sleep values from 1 to 10 seconds", "test_type": "positive", "expected_exit_code": 0, "expected_success": true, "expected_execution_path": [0, 1, 2, 3, 4, 5], "performance_benchmarks": {"min_duration": 19.0, "max_duration": 21.0}}
+# TEST_METADATA: {"description": "Sleep Block test - testing sleep values from 1 to 10 seconds", "test_type": "positive", "expected_exit_code": 0, "expected_success": true, "expected_execution_path": [0, 1, 2, 3, 4, 5], "performance_benchmarks": {"min_duration": 26.0, "max_duration": 30.0}}
 
 # Test sleep with values ranging from 1 to 10 seconds
 task=0

--- a/test_cases/scripts/intelligent_test_runner.py
+++ b/test_cases/scripts/intelligent_test_runner.py
@@ -685,7 +685,30 @@ class TestValidator:
                     f"Critical/High risk security test must be rejected (risk_level: {risk_level})"
                 )
 
-        # Phase 5: Performance test validation
+        # Phase 5: Duration validation (for any test type with min/max duration benchmarks)
+        if "performance_benchmarks" in metadata:
+            benchmarks = metadata["performance_benchmarks"]
+            actual_time = actual_results.get("execution_time", 0)
+
+            # Validate minimum duration
+            if "min_duration" in benchmarks:
+                min_duration = benchmarks["min_duration"]
+                if actual_time < min_duration:
+                    validation_results["passed"] = False
+                    validation_results["failures"].append(
+                        f"Execution time below minimum: {actual_time:.2f}s < {min_duration}s"
+                    )
+
+            # Validate maximum duration
+            if "max_duration" in benchmarks:
+                max_duration = benchmarks["max_duration"]
+                if actual_time > max_duration:
+                    validation_results["passed"] = False
+                    validation_results["failures"].append(
+                        f"Execution time exceeded maximum: {actual_time:.2f}s > {max_duration}s"
+                    )
+
+        # Phase 6: Performance test validation
         if metadata.get("test_type") == "performance":
             performance_metrics = actual_results.get("performance_metrics", {})
 


### PR DESCRIPTION
- Fixed incorrect performance benchmarks in metadata_sleep_range_test.txt
  - Changed min_duration from 19.0 to 26.0 seconds
  - Changed max_duration from 21.0 to 30.0 seconds
  - Benchmarks now correctly reflect sum of sleep durations (1+2.5+5+7.5+10=26s)

- Enhanced intelligent_test_runner.py validation
  - Added min_duration/max_duration validation for ANY test type
  - Previously only validated max_execution_time for performance tests
  - Now properly catches incorrect duration benchmarks
  - Validation runs in Phase 5 before performance-specific checks

This ensures test benchmarks are properly validated and prevents false positives from tests with incorrect timing expectations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)