### PR TITLE
Feature/test parallel conditional with loops

### DIFF
--- a/tasker/validation/task_validator.py
+++ b/tasker/validation/task_validator.py
@@ -294,15 +294,10 @@ class TaskValidator:
 
                     params_str = ", ".join(loop_params)
 
-                    # Self-contained error for INFO mode with subtask ID and parameters
+                    # Self-contained error with subtask ID and parameters
                     details = f"subtask {ref_id} ({params_str})"
                     self.errors.append(
                         f"Line {line_number}: Task {parent_task_id} ({parent_type}) references {details}. Loop control is only available for sequential tasks."
-                    )
-
-                    # Additional context for DEBUG mode
-                    self.debug_log(
-                        f"Line {line_number}: Task {parent_task_id} ({parent_type}): Subtask {ref_id} has loop parameters ({params_str}) which are not supported in {parent_type} execution."
                     )
 
     def parse_file(self):

--- a/tasker/validation/task_validator.py
+++ b/tasker/validation/task_validator.py
@@ -294,12 +294,13 @@ class TaskValidator:
 
                     params_str = ", ".join(loop_params)
 
-                    # Concise error for INFO mode
+                    # Self-contained error for INFO mode with subtask ID and parameters
+                    details = f"subtask {ref_id} ({params_str})"
                     self.errors.append(
-                        f"Line {line_number}: Task {parent_task_id} ({parent_type}): Loop control is only available for sequential tasks."
+                        f"Line {line_number}: Task {parent_task_id} ({parent_type}) references {details}. Loop control is only available for sequential tasks."
                     )
 
-                    # Detailed info for DEBUG mode with parameter details
+                    # Additional context for DEBUG mode
                     self.debug_log(
                         f"Line {line_number}: Task {parent_task_id} ({parent_type}): Subtask {ref_id} has loop parameters ({params_str}) which are not supported in {parent_type} execution."
                     )

--- a/tasker/validation/task_validator.py
+++ b/tasker/validation/task_validator.py
@@ -256,6 +256,55 @@ class TaskValidator:
                         f"Task {task_id} references task {ref_id} which is a '{ref_type}' task."
                     )
 
+    def _check_loop_in_subtasks(self, referenced_task_ids, line_number, parent_task_id, parent_type):
+        """
+        Check if any referenced subtasks have loop parameters (NOT SUPPORTED).
+
+        Loop control (loop, loop_break, next=loop) is ONLY available for sequential tasks.
+        Parallel and conditional subtasks cannot use loop parameters - they execute once.
+
+        Args:
+            referenced_task_ids: List of task IDs being referenced
+            line_number: Line number in task file for error reporting
+            parent_task_id: ID of the parent task (parallel/conditional)
+            parent_type: Type of parent task ('parallel' or 'conditional')
+
+        Side effects:
+            Appends errors to self.errors if loop parameters are detected in subtasks
+            Calls self.debug_log with detailed information in DEBUG mode
+        """
+        for ref_id in referenced_task_ids:
+            # Find the referenced task in our parsed tasks
+            ref_task = next((t[0] for t in self.tasks if self._safe_task_id_from_entry(t) == ref_id), None)
+            if ref_task:
+                # Check for any loop-related parameters
+                has_loop = 'loop' in ref_task
+                has_loop_break = 'loop_break' in ref_task
+                has_loop_next = ref_task.get('next') == 'loop'
+
+                if has_loop or has_loop_break or has_loop_next:
+                    # Build list of detected loop parameters
+                    loop_params = []
+                    if has_loop:
+                        loop_params.append(f"loop={ref_task['loop']}")
+                    if has_loop_break:
+                        loop_params.append(f"loop_break={ref_task['loop_break']}")
+                    if has_loop_next:
+                        loop_params.append("next=loop")
+
+                    params_str = ", ".join(loop_params)
+
+                    # Simple error for INFO mode
+                    self.errors.append(
+                        f"Line {line_number}: Task {parent_task_id} ({parent_type}): Subtask {ref_id} has loop parameters ({params_str}) which are not supported in {parent_type} execution. Loop control is only available for sequential tasks."
+                    )
+
+                    # Detailed info for DEBUG mode
+                    self.debug_log(
+                        f"Task {parent_task_id} ({parent_type}) references task {ref_id} which has loop parameters: {params_str}. "
+                        f"Loop control (loop, loop_break, next=loop) is ONLY supported in sequential tasks, not in parallel/conditional subtasks."
+                    )
+
     def parse_file(self):
         """Parse the task file into global variables and individual tasks."""
         if not os.path.exists(self.task_file):
@@ -730,6 +779,9 @@ class TaskValidator:
                     # CRITICAL: Check for nested conditional/parallel tasks (NOT SUPPORTED)
                     self._check_nested_conditional_or_parallel(referenced_task_ids, line_number, task_id)
 
+                    # CRITICAL: Check for loop parameters in subtasks (NOT SUPPORTED)
+                    self._check_loop_in_subtasks(referenced_task_ids, line_number, task_id, 'parallel')
+
                     # Check max_parallel vs number of tasks
                     if 'max_parallel' in task:
                         max_parallel = int(task['max_parallel'])
@@ -805,6 +857,9 @@ class TaskValidator:
 
             # CRITICAL: Check for nested conditional/parallel tasks (NOT SUPPORTED)
             self._check_nested_conditional_or_parallel(referenced_task_ids, line_number, task_id)
+
+            # CRITICAL: Check for loop parameters in subtasks (NOT SUPPORTED)
+            self._check_loop_in_subtasks(referenced_task_ids, line_number, task_id, 'conditional')
 
         except ValueError as e:
             self.errors.append(f"Line {line_number}: Task {task_id} has invalid task reference in {field_name} field: {str(e)}")

--- a/tasker/validation/task_validator.py
+++ b/tasker/validation/task_validator.py
@@ -294,15 +294,14 @@ class TaskValidator:
 
                     params_str = ", ".join(loop_params)
 
-                    # Simple error for INFO mode
+                    # Concise error for INFO mode
                     self.errors.append(
-                        f"Line {line_number}: Task {parent_task_id} ({parent_type}): Subtask {ref_id} has loop parameters ({params_str}) which are not supported in {parent_type} execution. Loop control is only available for sequential tasks."
+                        f"Line {line_number}: Task {parent_task_id} ({parent_type}): Loop control is only available for sequential tasks."
                     )
 
-                    # Detailed info for DEBUG mode
+                    # Detailed info for DEBUG mode with parameter details
                     self.debug_log(
-                        f"Task {parent_task_id} ({parent_type}) references task {ref_id} which has loop parameters: {params_str}. "
-                        f"Loop control (loop, loop_break, next=loop) is ONLY supported in sequential tasks, not in parallel/conditional subtasks."
+                        f"Line {line_number}: Task {parent_task_id} ({parent_type}): Subtask {ref_id} has loop parameters ({params_str}) which are not supported in {parent_type} execution."
                     )
 
     def parse_file(self):

--- a/test_cases/functional/test_conditional_with_loop.txt
+++ b/test_cases/functional/test_conditional_with_loop.txt
@@ -1,0 +1,43 @@
+# TEST_METADATA: {"description": "Conditional block with loop tasks - loops are ignored", "test_type": "positive", "expected_exit_code": 0, "expected_success": true, "skip_host_validation": true, "expected_conditional_tasks": {"1": ["10"]}}
+# Test conditional execution where subtasks have loop parameter
+# Loop control is ONLY available for sequential tasks - NOT for parallel/conditional subtasks
+# Expected behavior: loop parameters are silently ignored, tasks execute once
+# Expected task IDs: 1-10 (NOT 1-10.1, 1-10.2, etc.)
+# Note: Condition evaluates to TRUE, so task 10 executes (not task 20)
+
+task=0
+hostname=localhost
+command=/usr/bin/echo
+arguments=PRODUCTION
+exec=local
+
+# Conditional block with loop task in true branch (will execute)
+task=1
+type=conditional
+condition=@0_stdout@=PRODUCTION
+if_true_tasks=10
+if_false_tasks=20
+
+# True branch subtask with loop=3 (executes once, loop ignored)
+task=10
+hostname=localhost
+command=/usr/bin/echo
+arguments=Conditional subtask TRUE iteration
+exec=local
+loop=3
+next=loop
+
+# False branch subtask with loop (should be skipped)
+task=20
+hostname=localhost
+command=/usr/bin/echo
+arguments=Conditional subtask FALSE - should not execute
+exec=local
+loop=2
+next=loop
+
+task=2
+hostname=localhost
+command=/usr/bin/echo
+arguments=Conditional with loops completed
+exec=local

--- a/test_cases/functional/test_conditional_with_loop.txt
+++ b/test_cases/functional/test_conditional_with_loop.txt
@@ -1,9 +1,8 @@
-# TEST_METADATA: {"description": "Conditional block with loop tasks - loops are ignored", "test_type": "positive", "expected_exit_code": 0, "expected_success": true, "skip_host_validation": true, "expected_conditional_tasks": {"1": ["10"]}}
+# TEST_METADATA: {"description": "Conditional block with loop tasks - validation should reject", "test_type": "negative", "expected_exit_code": 20, "expected_success": false, "skip_host_validation": true, "validation_only": true}
 # Test conditional execution where subtasks have loop parameter
 # Loop control is ONLY available for sequential tasks - NOT for parallel/conditional subtasks
-# Expected behavior: loop parameters are silently ignored, tasks execute once
-# Expected task IDs: 1-10 (NOT 1-10.1, 1-10.2, etc.)
-# Note: Condition evaluates to TRUE, so task 10 executes (not task 20)
+# Expected behavior: Validation fails with exit code 20, rejecting loop parameters in subtasks
+# This test verifies that loop parameters in conditional subtasks are correctly rejected by validation
 
 task=0
 hostname=localhost

--- a/test_cases/functional/test_loop_in_conditional_validation.txt
+++ b/test_cases/functional/test_loop_in_conditional_validation.txt
@@ -1,0 +1,51 @@
+# TEST_METADATA: {"description": "Conditional block with loop subtasks - validation should fail", "test_type": "negative", "expected_exit_code": 20, "expected_success": false, "validation_only": true}
+# Test that conditional blocks reject subtasks with loop parameters
+# Loop control (loop, loop_break, next=loop) is ONLY available for sequential tasks
+# This test verifies that the validator correctly rejects loop parameters in conditional subtasks
+
+task=0
+hostname=localhost
+command=/usr/bin/echo
+arguments=PRODUCTION
+exec=local
+
+# Conditional block with loop subtasks (VALIDATION SHOULD FAIL)
+task=1
+type=conditional
+condition=@0_stdout@=PRODUCTION
+if_true_tasks=10,11
+if_false_tasks=20
+
+# True branch - subtask 10 with loop=3 (NOT SUPPORTED - should trigger validation error)
+task=10
+hostname=localhost
+command=/usr/bin/echo
+arguments=Conditional subtask TRUE iteration
+exec=local
+loop=3
+next=loop
+
+# True branch - subtask 11 with loop_break (NOT SUPPORTED - should trigger validation error)
+task=11
+hostname=localhost
+command=/usr/bin/echo
+arguments=Another conditional subtask TRUE
+exec=local
+loop=2
+loop_break=@11_exit_code@=0
+next=loop
+
+# False branch - subtask 20 with loop (NOT SUPPORTED - should trigger validation error)
+task=20
+hostname=localhost
+command=/usr/bin/echo
+arguments=Conditional subtask FALSE - should not execute
+exec=local
+loop=5
+next=loop
+
+task=2
+hostname=localhost
+command=/usr/bin/echo
+arguments=This should never execute
+exec=local

--- a/test_cases/functional/test_loop_in_parallel_validation.txt
+++ b/test_cases/functional/test_loop_in_parallel_validation.txt
@@ -1,0 +1,49 @@
+# TEST_METADATA: {"description": "Parallel block with loop subtasks - validation should fail", "test_type": "negative", "expected_exit_code": 20, "expected_success": false, "validation_only": true}
+# Test that parallel blocks reject subtasks with loop parameters
+# Loop control (loop, loop_break, next=loop) is ONLY available for sequential tasks
+# This test verifies that the validator correctly rejects loop parameters in parallel subtasks
+
+task=0
+hostname=localhost
+command=/usr/bin/echo
+arguments=Starting parallel loop validation test
+exec=local
+
+# Parallel block with loop subtasks (VALIDATION SHOULD FAIL)
+task=1
+type=parallel
+tasks=10,11,12
+max_parallel=3
+
+# Subtask 10 with loop=3 (NOT SUPPORTED - should trigger validation error)
+task=10
+hostname=localhost
+command=/usr/bin/echo
+arguments=Parallel subtask 10 iteration
+exec=local
+loop=3
+next=loop
+
+# Subtask 11 with loop_break (NOT SUPPORTED - should trigger validation error)
+task=11
+hostname=localhost
+command=/usr/bin/echo
+arguments=Parallel subtask 11 iteration
+exec=local
+loop=5
+loop_break=@11_exit_code@=0
+next=loop
+
+# Subtask 12 with only next=loop (NOT SUPPORTED - should trigger validation error)
+task=12
+hostname=localhost
+command=/usr/bin/echo
+arguments=Parallel subtask 12 iteration
+exec=local
+next=loop
+
+task=2
+hostname=localhost
+command=/usr/bin/echo
+arguments=This should never execute
+exec=local

--- a/test_cases/functional/test_parallel_with_loop.txt
+++ b/test_cases/functional/test_parallel_with_loop.txt
@@ -1,8 +1,8 @@
-# TEST_METADATA: {"description": "Parallel block with loop tasks - loops are ignored", "test_type": "positive", "expected_exit_code": 0, "expected_success": true, "skip_host_validation": true, "expected_subtasks": {"1": ["10", "11"]}}
+# TEST_METADATA: {"description": "Parallel block with loop tasks - validation should reject", "test_type": "negative", "expected_exit_code": 20, "expected_success": false, "skip_host_validation": true, "validation_only": true}
 # Test parallel execution where subtasks have loop parameter
 # Loop control is ONLY available for sequential tasks - NOT for parallel/conditional subtasks
-# Expected behavior: loop parameters are silently ignored, tasks execute once
-# Expected task IDs: 1-10, 1-11 (NOT 1-10.1, 1-10.2, etc.)
+# Expected behavior: Validation fails with exit code 20, rejecting loop parameters in subtasks
+# This test verifies that loop parameters in parallel subtasks are correctly rejected by validation
 
 task=0
 hostname=localhost

--- a/test_cases/functional/test_parallel_with_loop.txt
+++ b/test_cases/functional/test_parallel_with_loop.txt
@@ -1,0 +1,41 @@
+# TEST_METADATA: {"description": "Parallel block with loop tasks - loops are ignored", "test_type": "positive", "expected_exit_code": 0, "expected_success": true, "skip_host_validation": true, "expected_subtasks": {"1": ["10", "11"]}}
+# Test parallel execution where subtasks have loop parameter
+# Loop control is ONLY available for sequential tasks - NOT for parallel/conditional subtasks
+# Expected behavior: loop parameters are silently ignored, tasks execute once
+# Expected task IDs: 1-10, 1-11 (NOT 1-10.1, 1-10.2, etc.)
+
+task=0
+hostname=localhost
+command=/usr/bin/echo
+arguments=Starting parallel with loops test
+exec=local
+
+# Parallel block with loop tasks
+task=1
+type=parallel
+tasks=10,11
+max_parallel=2
+
+# Subtask 10 with loop=3
+task=10
+hostname=localhost
+command=/usr/bin/echo
+arguments=Parallel subtask 10 iteration
+exec=local
+loop=3
+next=loop
+
+# Subtask 11 with loop=2
+task=11
+hostname=localhost
+command=/usr/bin/echo
+arguments=Parallel subtask 11 iteration
+exec=local
+loop=2
+next=loop
+
+task=2
+hostname=localhost
+command=/usr/bin/echo
+arguments=Parallel with loops completed
+exec=local


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Validation now rejects loop-related parameters (loop, loop_break, next=loop) inside subtasks of parallel and conditional tasks.
  - Clear error messages and enhanced DEBUG logging when unsupported loop usage is detected.
  - Ensures loop control is limited to sequential tasks to prevent misconfiguration.

- Tests
  - Added functional tests verifying validation fails for loop parameters within conditional and parallel subtasks, with expected exit codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->