### PR TITLE
feat: Surface offending subtask in nested task validation error

### DIFF
--- a/tasker/validation/task_validator.py
+++ b/tasker/validation/task_validator.py
@@ -247,13 +247,10 @@ class TaskValidator:
             if ref_task and 'type' in ref_task:
                 ref_type = ref_task.get('type')
                 if ref_type in ['conditional', 'parallel']:
-                    # Simple error for INFO mode
+                    # Self-contained error with subtask ID and type
+                    details = f"subtask {ref_id} ({ref_type})"
                     self.errors.append(
-                        f"Line {line_number}: Nested conditional/parallel tasks are NOT supported."
-                    )
-                    # Detailed info for DEBUG mode
-                    self.debug_log(
-                        f"Task {task_id} references task {ref_id} which is a '{ref_type}' task."
+                        f"Line {line_number}: Task {task_id} references {details}. Nested conditional/parallel tasks are NOT supported."
                     )
 
     def _check_loop_in_subtasks(self, referenced_task_ids, line_number, parent_task_id, parent_type):


### PR DESCRIPTION
Made nested conditional/parallel validation error messages self-contained and actionable by including the specific subtask ID and type in INFO mode. Matches the pattern established for loop validation.

Before (generic):
  ERROR: Line 14: Nested conditional/parallel tasks are NOT supported.
  (Which subtask? Must check DEBUG or manually inspect)

After (self-contained):
  ERROR: Line 14: Task 1 references subtask 11 (conditional). Nested conditional/parallel tasks are NOT supported.
  (Immediately actionable - know exactly which subtask is nested)

Changes:
- Updated _check_nested_conditional_or_parallel() error message format
- Removed redundant debug_log call (info now in ERROR message)
- Consistent with loop validation message pattern

Each error now includes:
- Parent task ID (Task 1)
- Specific subtask ID (subtask 11)
- Subtask type (conditional or parallel)
- Clear constraint message

Test verified: metadata_conditional_nested_test.txt passes with exit code 20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Validation error messages are now clearer when a task references a conditional or parallel task. The message includes line number, task ID, subtask ID, and type, making issues easier to identify.
  - Removed redundant debug logging for these cases, reducing noise and consolidating information into a single, self-contained error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->